### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-psr7bridge": "^0.2.2 || ^1.0.0",
         "laminas/laminas-router": "^3.3.0",
-        "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-router": "^3.2",
         "psr/http-message": "^1.0.1"
     },
@@ -63,7 +62,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-expressive-zendrouter": "^3.0.1"
+    "conflict": {
+        "zendframework/zend-expressive-zendrouter": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70ab78eab5dcab1308dab5e427c18d16",
+    "content-hash": "cb78101ffc9b526d60e6ef1e483b5362",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -3897,8 +3897,5 @@
         "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.3"
-    },
     "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
