### PR TITLE
Treat PSR-7 request conversions as route failures

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,5 +1,6 @@
 {
   "ignore_php_platform_requirements": {
-    "8.1": true
+    "8.0": false,
+    "8.1": false
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "laminas": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,19 @@
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="./vendor/autoload.php"
+    colors="true"
+    convertDeprecationsToExceptions="true" >
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="Mezzio laminas-mvc Router Tests">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/test/LaminasRouterTest.php
+++ b/test/LaminasRouterTest.php
@@ -7,6 +7,7 @@ namespace MezzioTest\Router;
 use Closure;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Uri;
 use Laminas\Http\Request as LaminasRequest;
 use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\Psr7Bridge\Psr7ServerRequest;
@@ -559,5 +560,22 @@ class LaminasRouterTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('route not found');
         $router->generateUri('foo');
+    }
+
+    public function testMatchReturnsRouteFailureOnFailureToConvertPsr7Request(): void
+    {
+        $route = new Route('/some/path', $this->getMiddleware(), [RequestMethod::METHOD_GET], 'test');
+
+        $router = new LaminasRouter();
+        $router->addRoute($route);
+
+        $serverRequest = (new ServerRequest())
+            ->withUri(new Uri('https://${ip}/some/path'))
+            ->withHeader('Host', '${ip}')
+            ->withHeader('Accept', 'application/json');
+
+        $result = $router->match($serverRequest);
+
+        $this->assertTrue($result->isFailure());
     }
 }


### PR DESCRIPTION
This patch adds a try/catch block within the `LaminasRouter::match()` method around the conversion of the PSR-7 request to a laminas-http request.  It catches laminas-http `InvalidArgumentException`s, and checks for a previous exception matching a laminas-http `InvalidUriPartException`.  When detected, it returns a `RouteResult` indicating a routing failure; otherwise, it rethrows the exception.

The patch is intended to fix scenarios where the Host header is invalid (e.g. `${ip}`), leading to creation of an invalid URI.

Fixes #12
